### PR TITLE
Importer didn't appear to be detecting already imported downloads pro…

### DIFF
--- a/includes/class-dlm-legacy-importer.php
+++ b/includes/class-dlm-legacy-importer.php
@@ -151,7 +151,7 @@ class DLM_Legacy_Importer extends WP_Importer {
 			$already_imported = $wpdb->get_var( "
 				SELECT ID FROM {$wpdb->posts}
 				LEFT JOIN {$wpdb->postmeta} ON {$wpdb->posts}.ID = {$wpdb->postmeta}.post_id
-				WHERE meta_key = 'legacy_id'
+				WHERE meta_key = '_legacy_download_id'
 				AND post_status = 'publish'
 				AND post_type = 'dlm_download'
 				AND meta_value = '" . absint( $legacy_download->id ) . "'


### PR DESCRIPTION
…perly

*My Situation:*
I used the importer, and my server configuration has the importer stopping part-way through. So I've had to run the importer a few times. During this process, I've noticed that downloads are having duplicates created for them even though I saw there's some code which skips already imported downloads.

I noticed the meta_key that matches already imported downloads based on their legacy download id isn't the same as the meta key being saved when a download is imported.

*Fix:*
I made the $already_imported query use the same meta_key that's set when a download is imported.